### PR TITLE
Add sqlalchemy.func to model template

### DIFF
--- a/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
+++ b/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
@@ -4,7 +4,7 @@ from sqlalchemy.types import JSON as JSONType
 
 # Available for custom sqlalchemy_options
 import datetime
-from sqlalchemy import text
+from sqlalchemy import text, func
 
 from {{ template.db_import_path }} import db
 from {{ template.module_name }}.sqlalchemy.model.types import BigIntegerVariantType


### PR DESCRIPTION
So that we can use sqlalchemy functions in `default` and
`onchange`.

See:
- https://docs.sqlalchemy.org/en/13/core/functions.html
- https://docs.sqlalchemy.org/en/13/core/defaults.html#client-invoked-sql-expressions