### PR TITLE
Feature/validate entity id on request

### DIFF
--- a/bookshop/resources/Author.py
+++ b/bookshop/resources/Author.py
@@ -42,6 +42,12 @@ class AuthorResource(Resource):  # type: ignore
     @api.doc(id='get-author-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})  # noqa: E501
     @api.marshal_with(author_model)
     def get(self, authorId):  # type: ignore
+        id_validation_errors = author_schema.validate({
+          'author_id': authorId
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
         result: Optional[Author] = Author.query.filter_by(author_id=authorId).first()  # noqa: E501
         if result is None:
             abort(404)
@@ -91,6 +97,12 @@ class AuthorResource(Resource):  # type: ignore
 
     @api.expect(author_model, validate=False)
     def patch(self, authorId):  # type: ignore
+        id_validation_errors = author_schema.validate({
+          'author_id': authorId
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
         result: Optional[Author] = Author.query.filter_by(author_id=authorId)\
             .options(noload('*')).first()  # noqa: E501
 

--- a/bookshop/resources/Book.py
+++ b/bookshop/resources/Book.py
@@ -46,6 +46,12 @@ class BookResource(Resource):  # type: ignore
     @api.doc(id='get-book-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})  # noqa: E501
     @api.marshal_with(book_model)
     def get(self, bookId):  # type: ignore
+        id_validation_errors = book_schema.validate({
+          'book_id': bookId
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
         result: Optional[Book] = Book.query.filter_by(book_id=bookId).first()  # noqa: E501
         if result is None:
             abort(404)
@@ -95,6 +101,12 @@ class BookResource(Resource):  # type: ignore
 
     @api.expect(book_model, validate=False)
     def patch(self, bookId):  # type: ignore
+        id_validation_errors = book_schema.validate({
+          'book_id': bookId
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
         result: Optional[Book] = Book.query.filter_by(book_id=bookId)\
             .options(noload('*')).first()  # noqa: E501
 

--- a/bookshop/resources/BookGenre.py
+++ b/bookshop/resources/BookGenre.py
@@ -40,6 +40,12 @@ class BookGenreResource(Resource):  # type: ignore
     @api.doc(id='get-book_genre-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})  # noqa: E501
     @api.marshal_with(book_genre_model)
     def get(self, bookGenreId):  # type: ignore
+        id_validation_errors = book_genre_schema.validate({
+          'book_genre_id': bookGenreId
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
         result: Optional[BookGenre] = BookGenre.query.filter_by(book_genre_id=bookGenreId).first()  # noqa: E501
         if result is None:
             abort(404)
@@ -89,6 +95,12 @@ class BookGenreResource(Resource):  # type: ignore
 
     @api.expect(book_genre_model, validate=False)
     def patch(self, bookGenreId):  # type: ignore
+        id_validation_errors = book_genre_schema.validate({
+          'book_genre_id': bookGenreId
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
         result: Optional[BookGenre] = BookGenre.query.filter_by(book_genre_id=bookGenreId)\
             .options(noload('*')).first()  # noqa: E501
 

--- a/bookshop/resources/Genre.py
+++ b/bookshop/resources/Genre.py
@@ -38,6 +38,12 @@ class GenreResource(Resource):  # type: ignore
     @api.doc(id='get-genre-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})  # noqa: E501
     @api.marshal_with(genre_model)
     def get(self, genreId):  # type: ignore
+        id_validation_errors = genre_schema.validate({
+          'genre_id': genreId
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
         result: Optional[Genre] = Genre.query.filter_by(genre_id=genreId).first()  # noqa: E501
         if result is None:
             abort(404)
@@ -87,6 +93,12 @@ class GenreResource(Resource):  # type: ignore
 
     @api.expect(genre_model, validate=False)
     def patch(self, genreId):  # type: ignore
+        id_validation_errors = genre_schema.validate({
+          'genre_id': genreId
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
         result: Optional[Genre] = Genre.query.filter_by(genre_id=genreId)\
             .options(noload('*')).first()  # noqa: E501
 

--- a/bookshop/resources/RelatedBook.py
+++ b/bookshop/resources/RelatedBook.py
@@ -40,6 +40,12 @@ class RelatedBookResource(Resource):  # type: ignore
     @api.doc(id='get-related_book-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})  # noqa: E501
     @api.marshal_with(related_book_model)
     def get(self, relatedBookUuid):  # type: ignore
+        id_validation_errors = related_book_schema.validate({
+          'related_book_uuid': relatedBookUuid
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
         result: Optional[RelatedBook] = RelatedBook.query.filter_by(related_book_uuid=relatedBookUuid).first()  # noqa: E501
         if result is None:
             abort(404)
@@ -89,6 +95,12 @@ class RelatedBookResource(Resource):  # type: ignore
 
     @api.expect(related_book_model, validate=False)
     def patch(self, relatedBookUuid):  # type: ignore
+        id_validation_errors = related_book_schema.validate({
+          'related_book_uuid': relatedBookUuid
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
         result: Optional[RelatedBook] = RelatedBook.query.filter_by(related_book_uuid=relatedBookUuid)\
             .options(noload('*')).first()  # noqa: E501
 

--- a/bookshop/resources/Review.py
+++ b/bookshop/resources/Review.py
@@ -39,6 +39,12 @@ class ReviewResource(Resource):  # type: ignore
     @api.doc(id='get-review-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})  # noqa: E501
     @api.marshal_with(review_model)
     def get(self, reviewId):  # type: ignore
+        id_validation_errors = review_schema.validate({
+          'review_id': reviewId
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
         result: Optional[Review] = Review.query.filter_by(review_id=reviewId).first()  # noqa: E501
         if result is None:
             abort(404)
@@ -88,6 +94,12 @@ class ReviewResource(Resource):  # type: ignore
 
     @api.expect(review_model, validate=False)
     def patch(self, reviewId):  # type: ignore
+        id_validation_errors = review_schema.validate({
+          'review_id': reviewId
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
         result: Optional[Review] = Review.query.filter_by(review_id=reviewId)\
             .options(noload('*')).first()  # noqa: E501
 

--- a/genyrator/templates/resources/resource.j2
+++ b/genyrator/templates/resources/resource.j2
@@ -45,7 +45,14 @@ api = Namespace('{{ entity.resource_namespace }}',
 {{ entity.plural }}_many_schema = {{ entity.class_name }}Schema(many=True)
 
 {%- macro find_element_by_id() -%}
-    result: Optional[{{ entity.class_name }}] = {{ entity.class_name }}.query.filter_by({# -#}
+
+        id_validation_errors = {{ entity.python_name }}_schema.validate({
+          '{{ entity.identifier_column.python_name }}': {{ entity.identifier_column.json_property_name }}
+        }, session=db.session, partial=True)
+        if id_validation_errors:
+            abort(404)
+
+        result: Optional[{{ entity.class_name }}] = {{ entity.class_name }}.query.filter_by({# -#}
 {{ entity.identifier_column.python_name }}={# -#}
 {{ entity.identifier_column.json_property_name }}){# -#}
 {%- endmacro -%}

--- a/test/e2e/features/single_entity_operations.feature
+++ b/test/e2e/features/single_entity_operations.feature
@@ -27,6 +27,10 @@ Feature: performing operations on a simple schema
      When I make a "GET" request to "/book-store/1"
      Then I get http status "404"
 
+  Scenario: requesting an invalid identifier
+     When I make a "GET" request to "/book-store/invalid"
+     Then I get http status "404"
+
   Scenario: creating a new entity with correct data
      When I make a "PUT" request to "/book-store/3" with that json data
      Then I get http status "201"


### PR DESCRIPTION
Before this change, if the identifier column was a UUID and non-UUID
string was passed in on the URL then we'd get a 500. This change first
validates the ID with marshmallow before retrieving.