### PR TITLE
Add ability to add sqlalchemy options to foreign key

### DIFF
--- a/bookshop.py
+++ b/bookshop.py
@@ -25,6 +25,7 @@ book_entity = create_entity(
             foreign_key_relationship=ForeignKeyRelationship(
                 target_entity='author',
                 target_entity_identifier_column_type=TypeOption.UUID,
+                sqlalchemy_options={'ondelete': '"CASCADE"'},
             ),
         ),
         create_column(

--- a/bookshop/sqlalchemy/model/Book.py
+++ b/bookshop/sqlalchemy/model/Book.py
@@ -16,7 +16,7 @@ class Book(db.Model):  # type: ignore
     book_id =         db.Column(UUIDType, index=True, nullable=False)  # noqa: E501
     name =            db.Column(db.String, index=True, nullable=False)  # noqa: E501
     rating =          db.Column(db.Float, index=True, nullable=False)  # noqa: E501
-    author_id =       db.Column(db.BigInteger, db.ForeignKey('author.id'), nullable=True)  # noqa: E501
+    author_id =       db.Column(db.BigInteger, db.ForeignKey('author.id', ondelete="CASCADE"), nullable=True)  # noqa: E501
     collaborator_id = db.Column(db.BigInteger, db.ForeignKey('author.id'), nullable=True)  # noqa: E501
     published =       db.Column(db.Date, nullable=True)  # noqa: E501
     created =         db.Column(db.DateTime, server_default=text('CURRENT_TIMESTAMP'), nullable=True)  # noqa: E501

--- a/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
+++ b/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
@@ -30,13 +30,14 @@ class {{ template.entity.class_name }}(db.Model):  # type: ignore
     {{ column.python_name }} ={{ pad(column.python_name) }} db.Column(
     {%- if column.alias %}'{{ column.alias }}', {% endif -%}
     {{ column.sqlalchemy_type.value }}{# -#}
-    {%- if column.relationship is defined %}, db.ForeignKey('{{ column.relationship }}'){% endif %}
+    {%- if column.relationship is defined %}, db.ForeignKey('{{ column.relationship }}'{# -#}
+    {%- for option, value in column.foreign_key_sqlalchemy_options -%}
+    , {{ option }}={{ value }}
+    {%- endfor -%}){% endif %}
     {%- if column.index %}, index=True{% endif %}{# -#}
-    {%- if column.sqlalchemy_options -%}
-      {%- for option, value in column.sqlalchemy_options -%}
-      , {{ option }}={{ value }}
-      {%- endfor -%}
-    {%- endif -%}
+    {%- for option, value in column.sqlalchemy_options -%}
+    , {{ option }}={{ value }}
+    {%- endfor -%}
     , nullable={{ column.nullable | string }})  # noqa: E501
 {%- endfor %}
 


### PR DESCRIPTION
This allows us to add sqlalchemy options to a ForeignKey in the same way
that we do for Column objects.