### PR TITLE
factory boy creates uuids as strings rather than actual uuids

### DIFF
--- a/bookshop/sqlalchemy/fixture/Author.py
+++ b/bookshop/sqlalchemy/fixture/Author.py
@@ -1,3 +1,5 @@
+import uuid
+
 import factory
 
 from bookshop.sqlalchemy import db
@@ -9,5 +11,5 @@ class AuthorFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Author
         sqlalchemy_session = db.session
 
-    author_id = factory.Faker('uuid4')
+    author_id = uuid.uuid4()
     name = factory.Faker('pystr')

--- a/bookshop/sqlalchemy/fixture/Book.py
+++ b/bookshop/sqlalchemy/fixture/Book.py
@@ -1,3 +1,5 @@
+import uuid
+
 import factory
 
 from bookshop.sqlalchemy import db
@@ -9,6 +11,6 @@ class BookFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Book
         sqlalchemy_session = db.session
 
-    book_id = factory.Faker('uuid4')
+    book_id = uuid.uuid4()
     name = factory.Faker('pystr')
     rating = factory.Faker('pyfloat')

--- a/bookshop/sqlalchemy/fixture/BookGenre.py
+++ b/bookshop/sqlalchemy/fixture/BookGenre.py
@@ -1,3 +1,5 @@
+import uuid
+
 import factory
 
 from bookshop.sqlalchemy import db
@@ -9,4 +11,4 @@ class BookGenreFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = BookGenre
         sqlalchemy_session = db.session
 
-    book_genre_id = factory.Faker('uuid4')
+    book_genre_id = uuid.uuid4()

--- a/bookshop/sqlalchemy/fixture/Genre.py
+++ b/bookshop/sqlalchemy/fixture/Genre.py
@@ -1,3 +1,5 @@
+import uuid
+
 import factory
 
 from bookshop.sqlalchemy import db
@@ -9,4 +11,4 @@ class GenreFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Genre
         sqlalchemy_session = db.session
 
-    genre_id = factory.Faker('uuid4')
+    genre_id = uuid.uuid4()

--- a/bookshop/sqlalchemy/fixture/RelatedBook.py
+++ b/bookshop/sqlalchemy/fixture/RelatedBook.py
@@ -1,3 +1,5 @@
+import uuid
+
 import factory
 
 from bookshop.sqlalchemy import db
@@ -9,4 +11,4 @@ class RelatedBookFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = RelatedBook
         sqlalchemy_session = db.session
 
-    related_book_uuid = factory.Faker('uuid4')
+    related_book_uuid = uuid.uuid4()

--- a/bookshop/sqlalchemy/fixture/Review.py
+++ b/bookshop/sqlalchemy/fixture/Review.py
@@ -1,3 +1,5 @@
+import uuid
+
 import factory
 
 from bookshop.sqlalchemy import db
@@ -9,5 +11,5 @@ class ReviewFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Review
         sqlalchemy_session = db.session
 
-    review_id = factory.Faker('uuid4')
+    review_id = uuid.uuid4()
     text = factory.Faker('pystr')

--- a/genyrator/templates/sqlalchemy/fixture/fixture.j2
+++ b/genyrator/templates/sqlalchemy/fixture/fixture.j2
@@ -1,4 +1,6 @@
 {%- set entity = template.entity -%}
+import uuid
+
 import factory
 
 from {{ template.db_import_path }} import db
@@ -10,7 +12,7 @@ class {{ entity.class_name }}Factory(factory.alchemy.SQLAlchemyModelFactory):
         model = {{ entity.class_name }}
         sqlalchemy_session = db.session
 
-    {{ entity.identifier_column.python_name }} = factory.Faker('{{ entity.identifier_column.faker_method }}')
+    {{ entity.identifier_column.python_name }} = uuid.uuid4()
     {%- for column in entity.columns %}
         {%- if column.python_name != entity.identifier_column.python_name and
                column.faker_method is not none %}


### PR DESCRIPTION
This changes the fixtures to use the python `uuid.uuid4()` function for generating the uuids, rather than the Faker provider.  

The faker provider generates uuids as strings by default, which means that after committing the fixture to the database, you get a different type back for that column (as SQLAlchemy automatically coerces the string to a UUID).

This is causing problems in our tests in the API where we sometimes use the generated fixture before committing it, and sometimes use it after committing it.  This should fix that problem.