### PR TITLE
add faker options parameter so we can customise faker behaviour

### DIFF
--- a/bookshop/sqlalchemy/fixture/Author.py
+++ b/bookshop/sqlalchemy/fixture/Author.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 
 from bookshop.sqlalchemy import db
@@ -11,5 +9,5 @@ class AuthorFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Author
         sqlalchemy_session = db.session
 
-    author_id = uuid.uuid4()
+    author_id = factory.Faker('uuid4', cast_to=lambda x: x)
     name = factory.Faker('pystr')

--- a/bookshop/sqlalchemy/fixture/Book.py
+++ b/bookshop/sqlalchemy/fixture/Book.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 
 from bookshop.sqlalchemy import db
@@ -11,6 +9,6 @@ class BookFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Book
         sqlalchemy_session = db.session
 
-    book_id = uuid.uuid4()
+    book_id = factory.Faker('uuid4', cast_to=lambda x: x)
     name = factory.Faker('pystr')
     rating = factory.Faker('pyfloat')

--- a/bookshop/sqlalchemy/fixture/BookGenre.py
+++ b/bookshop/sqlalchemy/fixture/BookGenre.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 
 from bookshop.sqlalchemy import db
@@ -11,4 +9,4 @@ class BookGenreFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = BookGenre
         sqlalchemy_session = db.session
 
-    book_genre_id = uuid.uuid4()
+    book_genre_id = factory.Faker('uuid4', cast_to=lambda x: x)

--- a/bookshop/sqlalchemy/fixture/Genre.py
+++ b/bookshop/sqlalchemy/fixture/Genre.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 
 from bookshop.sqlalchemy import db
@@ -11,4 +9,4 @@ class GenreFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Genre
         sqlalchemy_session = db.session
 
-    genre_id = uuid.uuid4()
+    genre_id = factory.Faker('uuid4', cast_to=lambda x: x)

--- a/bookshop/sqlalchemy/fixture/RelatedBook.py
+++ b/bookshop/sqlalchemy/fixture/RelatedBook.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 
 from bookshop.sqlalchemy import db
@@ -11,4 +9,4 @@ class RelatedBookFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = RelatedBook
         sqlalchemy_session = db.session
 
-    related_book_uuid = uuid.uuid4()
+    related_book_uuid = factory.Faker('uuid4', cast_to=lambda x: x)

--- a/bookshop/sqlalchemy/fixture/Review.py
+++ b/bookshop/sqlalchemy/fixture/Review.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 
 from bookshop.sqlalchemy import db
@@ -11,5 +9,5 @@ class ReviewFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Review
         sqlalchemy_session = db.session
 
-    review_id = uuid.uuid4()
+    review_id = factory.Faker('uuid4', cast_to=lambda x: x)
     text = factory.Faker('pystr')

--- a/genyrator/entities/Column.py
+++ b/genyrator/entities/Column.py
@@ -4,8 +4,8 @@ from genyrator.inflector import pythonize, to_class_name, to_json_case, humanize
 from genyrator.types import (
     SqlAlchemyTypeOption, PythonTypeOption, TypeOption, type_option_to_sqlalchemy_type,
     type_option_to_python_type, type_option_to_default_value, RestplusTypeOption,
-    type_option_to_restplus_type,
-    type_option_to_faker_method)
+    type_option_to_restplus_type, type_option_to_faker_method, type_option_to_faker_options
+)
 
 
 @attr.s
@@ -24,6 +24,7 @@ class Column(object):
     json_property_name: str =                   attr.ib()
     type_option:        TypeOption =            attr.ib()
     faker_method:       str =                   attr.ib()
+    faker_options:      str =                   attr.ib()
     sqlalchemy_type:    SqlAlchemyTypeOption =  attr.ib()
     python_type:        PythonTypeOption =      attr.ib()
     restplus_type:      RestplusTypeOption =    attr.ib()
@@ -55,6 +56,7 @@ def create_column(
         alias:                    Optional[str] = None,
         foreign_key_relationship: Optional[ForeignKeyRelationship] = None,
         faker_method:             Optional[str] = None,
+        faker_options:            Optional[str] = None,
         sqlalchemy_options:       Optional[Dict[str, str]] = None,
 ) -> Union[Column, IdentifierColumn, ForeignKey]:
     """Return a column to be attached to an entity
@@ -111,6 +113,7 @@ def create_column(
         "nullable":           nullable,
         "alias":              alias,
         "faker_method":       faker_method,
+        "faker_options":      faker_options,
         "sqlalchemy_options": list(sqlalchemy_options.items()),
     }
     if foreign_key_relationship is not None:
@@ -126,9 +129,10 @@ def create_column(
 
 
 def create_identifier_column(
-        name:         str,
-        type_option:  TypeOption,
-        faker_method: Optional[str] = None,
+        name:          str,
+        type_option:   TypeOption,
+        faker_method:  Optional[str] = None,
+        faker_options: Optional[str] = None,
 ) -> IdentifierColumn:
     """Return an identifier column for an entity
 
@@ -145,9 +149,10 @@ def create_identifier_column(
                       default.
     """
     faker_method = faker_method if faker_method is not None else type_option_to_faker_method(type_option)
+    faker_options = type_option_to_faker_options(type_option)
     column = create_column(
         name=name, type_option=type_option, index=True, nullable=False,
-        identifier=True, faker_method=faker_method,
+        identifier=True, faker_method=faker_method, faker_options=faker_options
     )
     assert isinstance(column, IdentifierColumn)
     return column

--- a/genyrator/templates/sqlalchemy/fixture/fixture.j2
+++ b/genyrator/templates/sqlalchemy/fixture/fixture.j2
@@ -1,6 +1,4 @@
 {%- set entity = template.entity -%}
-import uuid
-
 import factory
 
 from {{ template.db_import_path }} import db
@@ -12,7 +10,7 @@ class {{ entity.class_name }}Factory(factory.alchemy.SQLAlchemyModelFactory):
         model = {{ entity.class_name }}
         sqlalchemy_session = db.session
 
-    {{ entity.identifier_column.python_name }} = uuid.uuid4()
+    {{ entity.identifier_column.python_name }} = factory.Faker('{{ entity.identifier_column.faker_method }}', {{ entity.identifier_column.faker_options if entity.identifier_column.faker_options }})
     {%- for column in entity.columns %}
         {%- if column.python_name != entity.identifier_column.python_name and
                column.faker_method is not none %}

--- a/genyrator/types.py
+++ b/genyrator/types.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 from enum import Enum
-from typing import Any
+from typing import Any, Optional
 from uuid import UUID
 
 
@@ -130,3 +130,10 @@ def type_option_to_faker_method(type_option: TypeOption) -> str:
         TypeOption.date:     'date_this_year',
         TypeOption.UUID:     'uuid4',
     }[type_option]
+
+
+def type_option_to_faker_options(type_option: TypeOption) -> Optional[str]:
+    if type_option == TypeOption.UUID:
+        return 'cast_to=lambda x: x'
+    else:
+        return None

--- a/test/e2e/features/fixtures.feature
+++ b/test/e2e/features/fixtures.feature
@@ -29,3 +29,17 @@ Feature: Creating fixtures from SQLAlchemy models
       And I initialize the database
      When I create a fixture for the "Book" entity
      Then the db contains "1" "Book" entity
+
+
+  Scenario: A fixture's identifier column is a UUID before it is in the database
+    Given I have an entity "Book" with properties
+      | name   | type  |
+      | title  | str   |
+      | rating | float |
+      And identifier column "book_id" with type "UUID"
+      And I create a schema from those entities
+      And I write that schema
+      And I import the generated app
+      And I initialize the database
+     When I create a fixture for the "Book" entity
+     Then the property "book_id" is type "UUID"


### PR DESCRIPTION
So the previous PR worked for genyrator but not for the data rest api as the uuids were static once generated. 

This changes the generation of uuids back to faker providers, but prevents the casting to a string that happens in Faker by default when calling the uuid4 provider.