### PR TITLE
Allow filtering by multiple values

### DIFF
--- a/bookshop/resources/Author.py
+++ b/bookshop/resources/Author.py
@@ -140,18 +140,18 @@ class AuthorResource(Resource):  # type: ignore
 class ManyAuthorResource(Resource):  # type: ignore
     def get(self):
         query = Author.query
-        param_author_id = request.args.get('author_id')
+        param_author_id = request.args.getlist('author_id')
         if param_author_id:
-            query = query.filter_by(author_id=param_author_id)
-        param_name = request.args.get('name')
+            query = query.filter(Author.author_id.in_(param_author_id))
+        param_name = request.args.getlist('name')
         if param_name:
-            query = query.filter_by(name=param_name)
-        param_favourite_author_id = request.args.get('favourite_author_id')
+            query = query.filter(Author.name.in_(param_name))
+        param_favourite_author_id = request.args.getlist('favourite_author_id')
         if param_favourite_author_id:
-            query = query.filter_by(favourite_author_id=param_favourite_author_id)
-        param_hated_author_id = request.args.get('hated_author_id')
+            query = query.filter(Author.favourite_author_id.in_(param_favourite_author_id))
+        param_hated_author_id = request.args.getlist('hated_author_id')
         if param_hated_author_id:
-            query = query.filter_by(hated_author_id=param_hated_author_id)
+            query = query.filter(Author.hated_author_id.in_(param_hated_author_id))
         result = query.all()
         return python_dict_to_json_dict({"data": [model_to_dict(r) for r in result]})
 

--- a/bookshop/resources/Book.py
+++ b/bookshop/resources/Book.py
@@ -144,30 +144,30 @@ class BookResource(Resource):  # type: ignore
 class ManyBookResource(Resource):  # type: ignore
     def get(self):
         query = Book.query
-        param_book_id = request.args.get('book_id')
+        param_book_id = request.args.getlist('book_id')
         if param_book_id:
-            query = query.filter_by(book_id=param_book_id)
-        param_name = request.args.get('name')
+            query = query.filter(Book.book_id.in_(param_book_id))
+        param_name = request.args.getlist('name')
         if param_name:
-            query = query.filter_by(name=param_name)
-        param_rating = request.args.get('rating')
+            query = query.filter(Book.name.in_(param_name))
+        param_rating = request.args.getlist('rating')
         if param_rating:
-            query = query.filter_by(rating=param_rating)
-        param_author_id = request.args.get('author_id')
+            query = query.filter(Book.rating.in_(param_rating))
+        param_author_id = request.args.getlist('author_id')
         if param_author_id:
-            query = query.filter_by(author_id=param_author_id)
-        param_collaborator_id = request.args.get('collaborator_id')
+            query = query.filter(Book.author_id.in_(param_author_id))
+        param_collaborator_id = request.args.getlist('collaborator_id')
         if param_collaborator_id:
-            query = query.filter_by(collaborator_id=param_collaborator_id)
-        param_published = request.args.get('published')
+            query = query.filter(Book.collaborator_id.in_(param_collaborator_id))
+        param_published = request.args.getlist('published')
         if param_published:
-            query = query.filter_by(published=param_published)
-        param_created = request.args.get('created')
+            query = query.filter(Book.published.in_(param_published))
+        param_created = request.args.getlist('created')
         if param_created:
-            query = query.filter_by(created=param_created)
-        param_updated = request.args.get('updated')
+            query = query.filter(Book.created.in_(param_created))
+        param_updated = request.args.getlist('updated')
         if param_updated:
-            query = query.filter_by(updated=param_updated)
+            query = query.filter(Book.updated.in_(param_updated))
         result = query.all()
         return python_dict_to_json_dict({"data": [model_to_dict(r) for r in result]})
 

--- a/bookshop/resources/BookGenre.py
+++ b/bookshop/resources/BookGenre.py
@@ -138,15 +138,15 @@ class BookGenreResource(Resource):  # type: ignore
 class ManyBookGenreResource(Resource):  # type: ignore
     def get(self):
         query = BookGenre.query
-        param_book_genre_id = request.args.get('book_genre_id')
+        param_book_genre_id = request.args.getlist('book_genre_id')
         if param_book_genre_id:
-            query = query.filter_by(book_genre_id=param_book_genre_id)
-        param_book_id = request.args.get('book_id')
+            query = query.filter(BookGenre.book_genre_id.in_(param_book_genre_id))
+        param_book_id = request.args.getlist('book_id')
         if param_book_id:
-            query = query.filter_by(book_id=param_book_id)
-        param_genre_id = request.args.get('genre_id')
+            query = query.filter(BookGenre.book_id.in_(param_book_id))
+        param_genre_id = request.args.getlist('genre_id')
         if param_genre_id:
-            query = query.filter_by(genre_id=param_genre_id)
+            query = query.filter(BookGenre.genre_id.in_(param_genre_id))
         result = query.all()
         return python_dict_to_json_dict({"data": [model_to_dict(r) for r in result]})
 

--- a/bookshop/resources/Genre.py
+++ b/bookshop/resources/Genre.py
@@ -136,12 +136,12 @@ class GenreResource(Resource):  # type: ignore
 class ManyGenreResource(Resource):  # type: ignore
     def get(self):
         query = Genre.query
-        param_genre_id = request.args.get('genre_id')
+        param_genre_id = request.args.getlist('genre_id')
         if param_genre_id:
-            query = query.filter_by(genre_id=param_genre_id)
-        param_title = request.args.get('title')
+            query = query.filter(Genre.genre_id.in_(param_genre_id))
+        param_title = request.args.getlist('title')
         if param_title:
-            query = query.filter_by(title=param_title)
+            query = query.filter(Genre.title.in_(param_title))
         result = query.all()
         return python_dict_to_json_dict({"data": [model_to_dict(r) for r in result]})
 

--- a/bookshop/resources/RelatedBook.py
+++ b/bookshop/resources/RelatedBook.py
@@ -138,15 +138,15 @@ class RelatedBookResource(Resource):  # type: ignore
 class ManyRelatedBookResource(Resource):  # type: ignore
     def get(self):
         query = RelatedBook.query
-        param_related_book_uuid = request.args.get('related_book_uuid')
+        param_related_book_uuid = request.args.getlist('related_book_uuid')
         if param_related_book_uuid:
-            query = query.filter_by(related_book_uuid=param_related_book_uuid)
-        param_book1_id = request.args.get('book1_id')
+            query = query.filter(RelatedBook.related_book_uuid.in_(param_related_book_uuid))
+        param_book1_id = request.args.getlist('book1_id')
         if param_book1_id:
-            query = query.filter_by(book1_id=param_book1_id)
-        param_book2_id = request.args.get('book2_id')
+            query = query.filter(RelatedBook.book1_id.in_(param_book1_id))
+        param_book2_id = request.args.getlist('book2_id')
         if param_book2_id:
-            query = query.filter_by(book2_id=param_book2_id)
+            query = query.filter(RelatedBook.book2_id.in_(param_book2_id))
         result = query.all()
         return python_dict_to_json_dict({"data": [model_to_dict(r) for r in result]})
 

--- a/bookshop/resources/Review.py
+++ b/bookshop/resources/Review.py
@@ -137,15 +137,15 @@ class ReviewResource(Resource):  # type: ignore
 class ManyReviewResource(Resource):  # type: ignore
     def get(self):
         query = Review.query
-        param_review_id = request.args.get('review_id')
+        param_review_id = request.args.getlist('review_id')
         if param_review_id:
-            query = query.filter_by(review_id=param_review_id)
-        param_text = request.args.get('text')
+            query = query.filter(Review.review_id.in_(param_review_id))
+        param_text = request.args.getlist('text')
         if param_text:
-            query = query.filter_by(text=param_text)
-        param_book_id = request.args.get('book_id')
+            query = query.filter(Review.text.in_(param_text))
+        param_book_id = request.args.getlist('book_id')
         if param_book_id:
-            query = query.filter_by(book_id=param_book_id)
+            query = query.filter(Review.book_id.in_(param_book_id))
         result = query.all()
         return python_dict_to_json_dict({"data": [model_to_dict(r) for r in result]})
 

--- a/genyrator/templates/resources/resource.j2
+++ b/genyrator/templates/resources/resource.j2
@@ -167,9 +167,9 @@ class Many{{ entity.class_name }}Resource(Resource):  # type: ignore
         {%- if entity.supports_get_one %}
         query = {{ entity.class_name }}.query
         {%- for column in entity.columns %}
-        param_{{ column.python_name }} = request.args.get('{{ column.python_name }}')
+        param_{{ column.python_name }} = request.args.getlist('{{ column.python_name }}')
         if param_{{ column.python_name }}:
-            query = query.filter_by({{ column.python_name }}=param_{{ column.python_name }})
+            query = query.filter({{ entity.class_name }}.{{ column.python_name }}.in_(param_{{ column.python_name }}))
         {%- endfor %}
         result = query.all()
         return python_dict_to_json_dict({"data": [model_to_dict(r) for r in result]})

--- a/test/e2e/features/list_entity_operations.feature
+++ b/test/e2e/features/list_entity_operations.feature
@@ -8,6 +8,9 @@ Feature: Listing and filtering entities
     When I list "book" filtered by "name=Peter Rabbit"
     Then I have "1" results
 
+  Scenario: Filtering my multiple names
+    When I list "book" filtered by "name=Peter Rabbit&name=Jungle Book"
+    Then I have "2" results
 
   Scenario: Filtering by rating
     When I list "book" filtered by "rating=3.2"


### PR DESCRIPTION
When querying a listing resource allow filtering by multiple values of a given field resulting in an OR.

For example:
`GET /book?title=foo&title=bar`
would return books with the title "foo" OR the title "bar".