### PR TITLE
Make model_to_dict hydrate eager relationships at the end of an api path

### DIFF
--- a/bookshop.py
+++ b/bookshop.py
@@ -119,6 +119,12 @@ book_entity = create_entity(
             ],
             route='genres',
         ),
+        create_api_path(
+            joined_entities=[
+                'author',
+            ],
+            route='author',
+        )
     ],
 )
 

--- a/bookshop/resources/Book.py
+++ b/bookshop/resources/Book.py
@@ -222,3 +222,27 @@ class Genre(Resource):  # type: ignore
         ))
 
         return result_dict
+
+
+@api.route('/book/<bookId>/author', endpoint='author')  # noqa: E501
+class Author(Resource):  # type: ignore
+    @api.doc(id='author', responses={401: 'Unauthorised', 404: 'Not Found'})  # noqa: E501
+    def get(self, bookId):  # type: ignore
+        result: Optional[Book] = Book \
+            .query \
+            .options(
+                joinedload('author')
+            ) \
+            .filter_by(
+                book_id=bookId) \
+            .first()  # noqa: E501
+        if result is None:
+            abort(404)
+        result_dict = python_dict_to_json_dict(model_to_dict(
+            sqlalchemy_model=result,
+            paths=[
+                'author',
+            ],
+        ))
+
+        return result_dict

--- a/test/e2e/features/joined_entity_operations.feature
+++ b/test/e2e/features/joined_entity_operations.feature
@@ -9,6 +9,13 @@ Feature: Posting new entities with foreign keys
      When I "put" a "book_genre" join entity
      Then I can see that genre in the response from "book/{id}/genres"
 
+  Scenario: Getting an eager relationship at the end of an API path
+    Given I put an example "book" entity
+      And I put an example "author" entity
+      And I put a book entity with a relationship to that author
+     When I get that book entity
+     Then I can see a hydrated book in the response from "book/{id}/author"
+
   Scenario: Putting a join entity where the join does not exist
     Given I put an incorrect "book_genre" join entity
      Then I get http status "400"

--- a/test/e2e/steps/bookshop_steps.py
+++ b/test/e2e/steps/bookshop_steps.py
@@ -138,6 +138,16 @@ def step_impl(context, url: str):
     assert_that(genre['id'], equal_to(context.genre_entity['id']))
 
 
+@then('I can see a hydrated book in the response from "{url}"')
+def step_impl(context, url: str):
+    url = url.replace('{id}', context.book_entity['id'])
+    response = make_request(client=context.client, endpoint=url, method='get')
+    assert_that(response.status_code, equal_to(200))
+    data = json.loads(response.data)
+    author = data["author"]
+    assert_that(author["books"][0]["id"], equal_to(context.book_entity["id"]))
+
+
 @step('I patch that "{entity_name}" entity with that "{entity_id}" id')
 def step_impl(context, entity_name: str, entity_id: str):
     patch_id = getattr(context, f'{entity_id}_entity')['id']


### PR DESCRIPTION
This change alters the behaviour of `model_to_dict` to cause it to hydrate the eager relationships at the end of an API path.

This doesn't do any filtering of the entities hydrated, so for example given a:
Book related to an Author, where both sides of the relationship are eager and have an API path, you would see the following:

```
/book/<id>/author:
{
  "id": b1,
  ...
  "author": {
    "id": a1,
    ...
    "books": [
      {
        "id": b1,
        ...,
      },
    ]
```
I'm not sure how often you would have a two way eager relationship so I haven't tried to prevent this from happening.