### PR TITLE
add explicit order by to guarantee collection order by id

### DIFF
--- a/bookshop/sqlalchemy/model/Author.py
+++ b/bookshop/sqlalchemy/model/Author.py
@@ -23,30 +23,35 @@ class Author(db.Model):  # type: ignore
         'Book',
         lazy=False,
         uselist=True,
+        order_by='Book.id',
         foreign_keys='Book.author_id',
     )
     favourite_book = db.relationship(
         'Book',
         lazy=False,
         uselist=False,
+        order_by='Book.id',
         foreign_keys='Book.author_id',
     )
     collaborations = db.relationship(
         'Book',
         lazy=False,
         uselist=True,
+        order_by='Book.id',
         foreign_keys='Book.collaborator_id',
     )
     favourite_of = db.relationship(
         'Author',
         lazy=True,
         uselist=True,
+        order_by='Author.id',
         foreign_keys=[favourite_author_id],
     )
     favourite_author = db.relationship(
         'Author',
         lazy=True,
         uselist=False,
+        order_by='Author.id',
         primaryjoin=id==favourite_author_id,
         remote_side=[id],
     )
@@ -54,12 +59,14 @@ class Author(db.Model):  # type: ignore
         'Author',
         lazy=True,
         uselist=True,
+        order_by='Author.id',
         foreign_keys=[hated_author_id],
     )
     hated_author = db.relationship(
         'Author',
         lazy=True,
         uselist=False,
+        order_by='Author.id',
         primaryjoin=id==hated_author_id,
         remote_side=[id],
     )

--- a/bookshop/sqlalchemy/model/Book.py
+++ b/bookshop/sqlalchemy/model/Book.py
@@ -27,29 +27,34 @@ class Book(db.Model):  # type: ignore
         'Author',
         lazy=False,
         uselist=False,
+        order_by='Author.id',
         foreign_keys=[author_id],
     )
     collaborator = db.relationship(
         'Author',
         lazy=False,
         uselist=False,
+        order_by='Author.id',
         foreign_keys=[collaborator_id],
     )
     reviews = db.relationship(
         'Review',
         lazy=True,
         uselist=True,
+        order_by='Review.id',
     )
     genre = db.relationship(
         'Genre',
         lazy=False,
         uselist=False,
+        order_by='Genre.id',
         secondary='book_genre',
     )
     related_books = db.relationship(
         'Book',
         lazy=True,
         uselist=True,
+        order_by='Book.id',
         secondary='related_book',
         primaryjoin='Book.id==RelatedBook.book1_id',
         secondaryjoin='Book.id==RelatedBook.book2_id',

--- a/bookshop/sqlalchemy/model/BookGenre.py
+++ b/bookshop/sqlalchemy/model/BookGenre.py
@@ -22,12 +22,14 @@ class BookGenre(db.Model):  # type: ignore
         'Book',
         lazy=False,
         uselist=False,
+        order_by='Book.id',
         foreign_keys=[book_id],
     )
     genre = db.relationship(
         'Genre',
         lazy=False,
         uselist=False,
+        order_by='Genre.id',
         foreign_keys=[genre_id],
     )
 

--- a/bookshop/sqlalchemy/model/Genre.py
+++ b/bookshop/sqlalchemy/model/Genre.py
@@ -21,6 +21,7 @@ class Genre(db.Model):  # type: ignore
         'Book',
         lazy=False,
         uselist=True,
+        order_by='Book.id',
         secondary='book_genre',
     )
 

--- a/bookshop/sqlalchemy/model/RelatedBook.py
+++ b/bookshop/sqlalchemy/model/RelatedBook.py
@@ -22,12 +22,14 @@ class RelatedBook(db.Model):  # type: ignore
         'Book',
         lazy=False,
         uselist=False,
+        order_by='Book.id',
         foreign_keys=[book1_id],
     )
     book2 = db.relationship(
         'Book',
         lazy=False,
         uselist=False,
+        order_by='Book.id',
         foreign_keys=[book2_id],
     )
 

--- a/bookshop/sqlalchemy/model/Review.py
+++ b/bookshop/sqlalchemy/model/Review.py
@@ -22,6 +22,7 @@ class Review(db.Model):  # type: ignore
         'Book',
         lazy=False,
         uselist=False,
+        order_by='Book.id',
         foreign_keys=[book_id],
     )
 

--- a/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
+++ b/genyrator/templates/sqlalchemy/model/sqlalchemy_model.j2
@@ -47,6 +47,7 @@ class {{ template.entity.class_name }}(db.Model):  # type: ignore
         '{{ relationship.target_entity_class_name }}',
         lazy={{ relationship.lazy | string }},
         uselist={{ relationship.join.value == 'to_many' | string }},
+        order_by='{{ relationship.target_entity_class_name | string }}.id',
     {%- if relationship.target_entity_class_name == template.entity.class_name -%}
       {%- if relationship.source_foreign_key_column_name %}
         primaryjoin=id=={{ relationship.source_foreign_key_column_name }},


### PR DESCRIPTION
We have noticed some odd behaviour when it comes to inconsistent ordering when accessing relationships in our apps.

This adds an explicit order by property to all relationships, ordering by the auto-incrementing id for each entity. 