### PR TITLE
Perform delete after querying for the entity in delete endpoint

### DIFF
--- a/bookshop/resources/Author.py
+++ b/bookshop/resources/Author.py
@@ -58,9 +58,10 @@ class AuthorResource(Resource):  # type: ignore
 
     @api.doc(id='delete-author-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})
     def delete(self, authorId):  # type: ignore
-        result: Optional[Author] = Author.query.filter_by(author_id=authorId).delete()
-        if result != 1:
+        result: Optional[Author] = Author.query.filter_by(author_id=authorId).first()
+        if result is None:
             abort(404)
+        db.session.delete(result)
         db.session.commit()
         return '', 204
 

--- a/bookshop/resources/Book.py
+++ b/bookshop/resources/Book.py
@@ -62,9 +62,10 @@ class BookResource(Resource):  # type: ignore
 
     @api.doc(id='delete-book-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})
     def delete(self, bookId):  # type: ignore
-        result: Optional[Book] = Book.query.filter_by(book_id=bookId).delete()
-        if result != 1:
+        result: Optional[Book] = Book.query.filter_by(book_id=bookId).first()
+        if result is None:
             abort(404)
+        db.session.delete(result)
         db.session.commit()
         return '', 204
 

--- a/bookshop/resources/BookGenre.py
+++ b/bookshop/resources/BookGenre.py
@@ -56,9 +56,10 @@ class BookGenreResource(Resource):  # type: ignore
 
     @api.doc(id='delete-book_genre-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})
     def delete(self, bookGenreId):  # type: ignore
-        result: Optional[BookGenre] = BookGenre.query.filter_by(book_genre_id=bookGenreId).delete()
-        if result != 1:
+        result: Optional[BookGenre] = BookGenre.query.filter_by(book_genre_id=bookGenreId).first()
+        if result is None:
             abort(404)
+        db.session.delete(result)
         db.session.commit()
         return '', 204
 

--- a/bookshop/resources/Genre.py
+++ b/bookshop/resources/Genre.py
@@ -54,9 +54,10 @@ class GenreResource(Resource):  # type: ignore
 
     @api.doc(id='delete-genre-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})
     def delete(self, genreId):  # type: ignore
-        result: Optional[Genre] = Genre.query.filter_by(genre_id=genreId).delete()
-        if result != 1:
+        result: Optional[Genre] = Genre.query.filter_by(genre_id=genreId).first()
+        if result is None:
             abort(404)
+        db.session.delete(result)
         db.session.commit()
         return '', 204
 

--- a/bookshop/resources/RelatedBook.py
+++ b/bookshop/resources/RelatedBook.py
@@ -56,9 +56,10 @@ class RelatedBookResource(Resource):  # type: ignore
 
     @api.doc(id='delete-related_book-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})
     def delete(self, relatedBookUuid):  # type: ignore
-        result: Optional[RelatedBook] = RelatedBook.query.filter_by(related_book_uuid=relatedBookUuid).delete()
-        if result != 1:
+        result: Optional[RelatedBook] = RelatedBook.query.filter_by(related_book_uuid=relatedBookUuid).first()
+        if result is None:
             abort(404)
+        db.session.delete(result)
         db.session.commit()
         return '', 204
 

--- a/bookshop/resources/Review.py
+++ b/bookshop/resources/Review.py
@@ -55,9 +55,10 @@ class ReviewResource(Resource):  # type: ignore
 
     @api.doc(id='delete-review-by-id', responses={401: 'Unauthorised', 404: 'Not Found'})
     def delete(self, reviewId):  # type: ignore
-        result: Optional[Review] = Review.query.filter_by(review_id=reviewId).delete()
-        if result != 1:
+        result: Optional[Review] = Review.query.filter_by(review_id=reviewId).first()
+        if result is None:
             abort(404)
+        db.session.delete(result)
         db.session.commit()
         return '', 204
 

--- a/genyrator/templates/resources/resource.j2
+++ b/genyrator/templates/resources/resource.j2
@@ -82,9 +82,10 @@ class {{ entity.class_name }}Resource(Resource):  # type: ignore
         result: Optional[{{ entity.class_name }}] = {{ entity.class_name }}.query.filter_by({# -#}
 {{ entity.identifier_column.python_name }}={# -#}
 {{ entity.identifier_column.json_property_name }}){# -#}
-.delete()
-        if result != 1:
+.first()
+        if result is None:
             abort(404)
+        db.session.delete(result)
         db.session.commit()
         return '', 204
     {%- endif -%}{# delete_one method #}


### PR DESCRIPTION
We had an issue with SQLAlchemy Continuum deletes where the VersioningManager was unable to find a connection when performing a delete - the error looked a bit like this:

```python
 Traceback (most recent call last):
 --- snipped 10 stack items ---
   File "/opt/app/tnt/generated/resources/HiveSubProjectTender.py", line 59, in delete
     result: Optional[HiveSubProjectTender] = HiveSubProjectTender.query.filter_by(sub_project_tender_uuid=subProjectTenderUuid).delete()
--- snipped 10 stack items ---
 KeyError: Engine(postgresql+psycopg2://docker:***@db:5432/postgres?sslmode=verify-ca&sslrootcert=certs/server.crt)
 172.18.0.8 - - [15/Sep/2020 14:39:28] "DELETE /generated/hive-sub-project-tender/e415c58f-4f46-4511-a729-a06ae8952675 HTTP/1.1" 500 -
 172.18.0.8 - - [15/Sep/2020 14:39:28] "DELETE /generated/mrdb-rate/44f9bbf9-8e07-4a6f-b1a2-0d00303b9f92 HTTP/1.1" 404 -
 [2020-09-15 14:39:28,784] ERROR in app: Exception on /generated/hive-sub-project-tender/2a45f988-7e79-49e6-bbb2-834dec459383 [DELETE]
 Traceback (most recent call last):
 File "/usr/local/lib/python3.8/site-packages/sqlalchemy_continuum/manager.py", line 412, in append_association_operation
 uow = self.units_of_work[conn]
 KeyError: <sqlalchemy.engine.base.Connection object at 0x7f50b2f91280>
```

Making the query for the model explicit, then performing a delete on the session seems to resolve the issue.