### PR TITLE
Import all fixture factories to  to make them nicer to import

### DIFF
--- a/bookshop/sqlalchemy/fixture/__init__.py
+++ b/bookshop/sqlalchemy/fixture/__init__.py
@@ -1,0 +1,7 @@
+# flake8: noqa
+from bookshop.sqlalchemy.fixture.Author import AuthorFactory
+from bookshop.sqlalchemy.fixture.Book import BookFactory
+from bookshop.sqlalchemy.fixture.BookGenre import BookGenreFactory
+from bookshop.sqlalchemy.fixture.Genre import GenreFactory
+from bookshop.sqlalchemy.fixture.RelatedBook import RelatedBookFactory
+from bookshop.sqlalchemy.fixture.Review import ReviewFactory

--- a/genyrator/entities/Template.py
+++ b/genyrator/entities/Template.py
@@ -147,6 +147,12 @@ class ConvertDictToMarshmallow(Template):
 
 
 @attr.s
+class FixtureInit(Template):
+    module_name:    str =          attr.ib()
+    imports:        List[Import] = attr.ib()
+
+
+@attr.s
 class Fixture(Template):
     db_import_path: str = attr.ib()
     module_name: str =    attr.ib()

--- a/genyrator/template_config.py
+++ b/genyrator/template_config.py
@@ -56,7 +56,9 @@ def create_template_config(
         ),
     ]
     fixtures = [
-        create_template(Template.Template, ['sqlalchemy', 'fixture', '__init__']),
+        create_template(Template.FixtureInit, ['sqlalchemy', 'fixture', '__init__'],
+                        imports=[Template.Import(e.class_name, [e.class_name]) for e in entities],
+                        module_name=module_name),
         *[create_template(
             Template.Fixture, ['sqlalchemy', 'fixture', 'fixture'], module_name=module_name,
             db_import_path=db_import_path, out_path=Template.OutPath((['sqlalchemy', 'fixture'], entity.class_name)),

--- a/genyrator/templates/sqlalchemy/fixture/__init__.j2
+++ b/genyrator/templates/sqlalchemy/fixture/__init__.j2
@@ -1,0 +1,4 @@
+# flake8: noqa
+{% for import in template.imports|sort(attribute='module_name') -%}
+from {{ template.module_name }}.sqlalchemy.fixture.{{ import.module_name }} import {% for import in import.imports %}{{ import }}Factory{% endfor %}
+{% endfor %}


### PR DESCRIPTION
This is a little quality of life PR to make it a bit easier to import from `foo.bar.fixture` rather than having to go into each fixture definition explicitly.